### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,16 +12,16 @@ i2CHelper	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ############################################
 
-setBit	    KEYWORD2
+setBit		KEYWORD2
 setRegister	KEYWORD2
 set2Registers	KEYWORD2
-getBit      KEYWORD2
-getRegister KEYWORD2
-get2Registers KEYWORD2
+getBit	KEYWORD2
+getRegister	KEYWORD2
+get2Registers	KEYWORD2
 
 
 ############################################
 # Constants (LITERAL1)
 ############################################
 
-i2caddr     LITERAL1
+i2caddr	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords